### PR TITLE
Fix homebrew install command

### DIFF
--- a/site/data/download/f_others.yml
+++ b/site/data/download/f_others.yml
@@ -12,8 +12,8 @@ column_2:
   - items:
     - title: Homebrew Cask
       info:
-        - On Mac OS X you can also install ZAP using [Homebrew Cask](https://formulae.brew.sh/cask/owasp-zap)
-        - "To install: `brew cask install owasp-zap`"
+        - On macOS you can also install ZAP using [Homebrew Cask](https://formulae.brew.sh/cask/owasp-zap)
+        - "To install: `brew install --cask  owasp-zap`"
     - title: Flathub
       info:
         - On Linux systems you can also use [Flathub](https://flathub.org/apps/details/org.zaproxy.ZAP).


### PR DESCRIPTION

** Summary**

Fix the command for installation via Homebrew on macOS. The current version of Homebrew doesn't accept how 

** Test plan**

Try the old way in the command line: "brew cask install owasp-zap" -- won't work. Using "brew install --cask owasp-zap" does. Also updated Max OS X to macOS.

Updated
![Cute animal](!https://unsplash.com/photos/NaqYGZDEUuE/download?force=true&w=640)
